### PR TITLE
Route component must be child of Switch component

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -5,10 +5,10 @@ import PlayPageRouter from "./pages/Play/router"
 const MainRouter: React.FC = () => {
   return (
     <>
-    <MainPageRouter />
-    <Switch>
-      <PlayPageRouter />
-    </Switch>
+      <Switch>
+        <MainPageRouter />
+        <PlayPageRouter />
+      </Switch>
     </>
   )
 }


### PR DESCRIPTION
```tsx
import { Route } from "react-router"
import Main from "./Main"

const MainPageRouter: React.FC = () => {
  return <Route exact path="/" component={Main}/>
}

export default MainPageRouter
```

🤔 페이지마다 위 같이 라우터를 분산한 이유가 뭔가요?